### PR TITLE
docs: improve project onboarding README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to Flash POS
+
+Thanks for helping improve Flash POS. This guide keeps contributions easy to
+review and safe for a payment-focused mobile app.
+
+## Before You Start
+
+1. Check the issue tracker for an existing issue.
+2. Comment on the issue if you plan to work on it, especially for bounty work.
+3. Keep credentials, API keys, wallet data, screenshots with private account
+   information, and production payment details out of commits and PR comments.
+
+## Local Setup
+
+```bash
+git clone https://github.com/lnflash/flash-pos.git
+cd flash-pos
+yarn install
+cp .env.example .env
+yarn start
+```
+
+Use `yarn android` or `yarn ios` from a second terminal to run the app. NFC,
+printing, and production payment flows should be tested on physical devices
+when your change touches those areas.
+
+## Development Workflow
+
+1. Create a focused branch from `main`.
+2. Make the smallest change that solves the issue.
+3. Add or update docs when behavior, setup, or operator expectations change.
+4. Run the relevant checks:
+
+```bash
+yarn test
+yarn lint
+```
+
+For Android release-sensitive changes, also smoke-check:
+
+```bash
+yarn apk-android
+```
+
+## Pull Request Checklist
+
+- Describe the user-visible change.
+- Link the issue being fixed.
+- Include screenshots or screen recordings for UI changes.
+- Note the test commands you ran.
+- Call out any hardware-tested flows, such as NFC cards or printers.
+- Explain any follow-up work that is intentionally left out of scope.
+
+## Bounty Notes
+
+Some issues may include Lightning or other reward terms. Eligibility depends on
+the issue description and maintainer review. Do not include payment addresses,
+API secrets, private keys, or other sensitive payment details in the repository.
+Share payout details only through the maintainer-approved private process.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,155 @@
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+# Flash POS
 
-# Getting Started
+Flash POS is a React Native point-of-sale app for merchants who accept Bitcoin
+and Lightning payments. It combines invoice creation, NFC flashcard support,
+customer rewards, transaction history, and receipt printing in one mobile
+checkout flow.
 
->**Note**: Make sure you have completed the [React Native - Environment Setup](https://reactnative.dev/docs/environment-setup) instructions till "Creating a new application" step, before proceeding.
+## Screenshots
 
-## Step 1: Start the Metro Server
+<p align="center">
+  <img src="./docs/screenshots/keypad.svg" alt="Amount entry keypad" width="240" />
+  <img src="./docs/screenshots/invoice.svg" alt="Lightning invoice screen" width="240" />
+  <img src="./docs/screenshots/flashcard-balance.svg" alt="Flashcard balance screen" width="240" />
+</p>
 
-First, you will need to start **Metro**, the JavaScript _bundler_ that ships _with_ React Native.
+## Features
 
-To start Metro, run the following command from the _root_ of your React Native project:
+- Create Lightning invoices for customer payments.
+- Let customers pay with QR code, copied invoice text, shared invoice text, or
+  supported NFC flashcards.
+- Award configurable customer rewards for Lightning or external cash/card
+  payments.
+- View transaction history and flashcard activity.
+- Configure reward settings and event-mode promotions behind PIN protection.
+- Print receipts through supported mobile receipt-printer integrations.
+
+## Hardware Support
+
+Flash POS can run on Android and iOS devices supported by React Native 0.76.
+The optional hardware-dependent flows require:
+
+- An NFC-capable phone or tablet for reading Bolt Card/Flashcard-compatible
+  NDEF tags.
+- NFC enabled at the operating-system level before scanning customer cards.
+- A Bluetooth, network, or platform-supported receipt printer when receipt
+  printing is enabled.
+- A configured Lightning backend, GraphQL API, and BTCPay Server pull-payment
+  setup for production payments and rewards.
+
+NFC and printer behavior should be validated on real devices because most
+simulators do not expose the native hardware APIs used by the app.
+
+## Local Development
+
+### Prerequisites
+
+- Node.js 18 or newer.
+- Yarn.
+- Android Studio and a configured Android SDK for Android development.
+- Xcode and CocoaPods for iOS development on macOS.
+- A physical device for NFC or printer testing.
+
+### Setup
 
 ```bash
-# using npm
-npm start
+git clone https://github.com/lnflash/flash-pos.git
+cd flash-pos
+yarn install
+cp .env.example .env
+```
 
-# OR using Yarn
+Edit `.env` with your local or staging service endpoints. The most important
+values are:
+
+```bash
+FLASH_GRAPHQL_URI=https://api.your-server.com/graphql
+FLASH_GRAPHQL_WS_URI=wss://api.your-server.com/graphql
+FLASH_LN_ADDRESS_URL=https://ln.your-server.com
+FLASH_LN_ADDRESS=your-domain.com
+BTC_PAY_SERVER=https://btcpay.your-server.com
+PULL_PAYMENT_ID=your-btcpay-pull-payment-id
+```
+
+See [docs/environment-configuration.md](./docs/environment-configuration.md)
+for the full environment reference.
+
+### Run the App
+
+Start Metro:
+
+```bash
 yarn start
 ```
 
-## Step 2: Start your Application
-
-Let Metro Bundler run in its _own_ terminal. Open a _new_ terminal from the _root_ of your React Native project. Run the following command to start your _Android_ or _iOS_ app:
-
-### For Android
+Run Android:
 
 ```bash
-# using npm
-npm run android
-
-# OR using Yarn
 yarn android
 ```
 
-### For iOS
+Run iOS:
 
 ```bash
-# using npm
-npm run ios
-
-# OR using Yarn
+cd ios
+pod install
+cd ..
 yarn ios
 ```
 
-If everything is set up _correctly_, you should see your new app running in your _Android Emulator_ or _iOS Simulator_ shortly provided you have set up your emulator/simulator correctly.
+### Validate Changes
 
-This is one way to run your app — you can also run it directly from within Android Studio and Xcode respectively.
+```bash
+yarn test
+yarn lint
+```
 
-## Step 3: Modifying your App
+For release smoke checks:
 
-Now that you have successfully run the app, let's modify it.
+```bash
+yarn apk-android
+yarn aab-android
+```
 
-1. Open `App.tsx` in your text editor of choice and edit some lines.
-2. For **Android**: Press the <kbd>R</kbd> key twice or select **"Reload"** from the **Developer Menu** (<kbd>Ctrl</kbd> + <kbd>M</kbd> (on Window and Linux) or <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (on macOS)) to see your changes!
+## Project Structure
 
-   For **iOS**: Hit <kbd>Cmd ⌘</kbd> + <kbd>R</kbd> in your iOS Simulator to reload the app and see your changes!
+```text
+flash-pos/
+  App.tsx                    Root providers and app shell
+  src/routes/                React Navigation stack and tabs
+  src/screens/               POS, invoice, rewards, profile, and history screens
+  src/components/            Shared UI and feature components
+  src/contexts/              Activity and NFC flashcard context providers
+  src/graphql/               Apollo client, mutations, subscriptions, queries
+  src/store/                 Redux Toolkit slices and persistence
+  docs/                      Detailed architecture and feature documentation
+  android/                   Android native project
+  ios/                       iOS native project
+```
 
-## Congratulations! :tada:
+## Documentation
 
-You've successfully run and modified your React Native App. :partying_face:
+- [Project overview](./docs/01-project-overview.md)
+- [Development setup](./docs/02-development-setup.md)
+- [API integration](./docs/04-api-integration.md)
+- [Screens and navigation](./docs/05-screens-navigation.md)
+- [NFC integration](./docs/06-nfc-integration.md)
+- [Rewards system](./docs/07-rewards-system.md)
+- [Printing system](./docs/08-printing-system.md)
+- [Testing](./docs/10-testing.md)
+- [Deployment](./docs/11-deployment.md)
+- [Security](./docs/12-security.md)
 
-### Now what?
+## Contributor Quick Start
 
-- If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
-- If you're curious to learn more about React Native, check out the [Introduction to React Native](https://reactnative.dev/docs/getting-started).
+1. Pick an open issue or create one before starting larger work.
+2. Create a branch from `main` and keep your change focused.
+3. Update related docs and run `yarn test` plus `yarn lint` before opening a
+   pull request.
 
-# Troubleshooting
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow.
 
-If you can't get this to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.
+## License
 
-# Learn More
-
-To learn more about React Native, take a look at the following resources:
-
-- [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
-- [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
-- [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
-- [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+No repository license file is currently included. Confirm licensing with the
+maintainers before redistributing or publishing derived builds.

--- a/docs/screenshots/flashcard-balance.svg
+++ b/docs/screenshots/flashcard-balance.svg
@@ -1,0 +1,24 @@
+<svg width="390" height="844" viewBox="0 0 390 844" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Flashcard balance screen</title>
+  <desc id="desc">A phone mockup showing a scanned customer flashcard balance and recent activity.</desc>
+  <rect width="390" height="844" rx="36" fill="#111"/>
+  <rect x="18" y="18" width="354" height="808" rx="28" fill="#fff"/>
+  <text x="195" y="78" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#202124">Flashcard Balance</text>
+  <rect x="72" y="142" width="246" height="146" rx="22" fill="#007856"/>
+  <circle cx="276" cy="178" r="22" fill="#fff" fill-opacity=".18"/>
+  <text x="96" y="188" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#fff">FLASH CARD</text>
+  <text x="96" y="238" font-family="Arial, sans-serif" font-size="15" fill="#fff" fill-opacity=".8">Tap to pay or receive rewards</text>
+  <text x="195" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" font-weight="700" fill="#202124">12,450 sats</text>
+  <text x="195" y="392" text-anchor="middle" font-family="Arial, sans-serif" font-size="15" fill="#687076">Approx. balance after scan</text>
+  <text x="54" y="458" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#202124">Recent Activity</text>
+  <g font-family="Arial, sans-serif">
+    <rect x="54" y="486" width="282" height="64" rx="16" fill="#f3f5f7"/>
+    <text x="76" y="514" font-size="15" font-weight="700" fill="#202124">Coffee purchase</text>
+    <text x="76" y="536" font-size="13" fill="#687076">Lightning payment</text>
+    <text x="314" y="524" text-anchor="end" font-size="15" font-weight="700" fill="#202124">-2,100</text>
+    <rect x="54" y="566" width="282" height="64" rx="16" fill="#f3f5f7"/>
+    <text x="76" y="594" font-size="15" font-weight="700" fill="#202124">Reward</text>
+    <text x="76" y="616" font-size="13" fill="#687076">Loyalty points</text>
+    <text x="314" y="604" text-anchor="end" font-size="15" font-weight="700" fill="#007856">+250</text>
+  </g>
+</svg>

--- a/docs/screenshots/invoice.svg
+++ b/docs/screenshots/invoice.svg
@@ -1,0 +1,26 @@
+<svg width="390" height="844" viewBox="0 0 390 844" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Flash POS Lightning invoice screen</title>
+  <desc id="desc">A phone mockup showing a Lightning invoice QR code with copy, share, and NFC payment options.</desc>
+  <rect width="390" height="844" rx="36" fill="#111"/>
+  <rect x="18" y="18" width="354" height="808" rx="28" fill="#fff"/>
+  <text x="195" y="78" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#202124">Pay to merchant</text>
+  <rect x="42" y="108" width="86" height="42" rx="21" fill="#f3f5f7"/>
+  <text x="85" y="135" text-anchor="middle" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#007856">NFC</text>
+  <text x="195" y="198" text-anchor="middle" font-family="Arial, sans-serif" font-size="42" font-weight="700" fill="#202124">$12.50</text>
+  <text x="195" y="232" text-anchor="middle" font-family="Arial, sans-serif" font-size="15" fill="#687076">Invoice expires in 10:00</text>
+  <rect x="75" y="270" width="240" height="240" rx="24" fill="#f3f5f7"/>
+  <g fill="#202124">
+    <rect x="102" y="298" width="54" height="54" rx="8"/>
+    <rect x="234" y="298" width="54" height="54" rx="8"/>
+    <rect x="102" y="430" width="54" height="54" rx="8"/>
+    <rect x="176" y="322" width="18" height="18"/><rect x="198" y="344" width="18" height="18"/><rect x="176" y="366" width="18" height="18"/>
+    <rect x="220" y="388" width="18" height="18"/><rect x="242" y="410" width="18" height="18"/><rect x="176" y="432" width="18" height="18"/>
+    <rect x="198" y="454" width="18" height="18"/><rect x="264" y="454" width="18" height="18"/>
+  </g>
+  <rect x="58" y="552" width="120" height="48" rx="14" fill="#eef7f4"/>
+  <text x="118" y="582" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#007856">Copy</text>
+  <rect x="212" y="552" width="120" height="48" rx="14" fill="#eef7f4"/>
+  <text x="272" y="582" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#007856">Share</text>
+  <rect x="36" y="726" width="318" height="56" rx="16" fill="#007856"/>
+  <text x="195" y="760" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#fff">Back</text>
+</svg>

--- a/docs/screenshots/keypad.svg
+++ b/docs/screenshots/keypad.svg
@@ -1,0 +1,22 @@
+<svg width="390" height="844" viewBox="0 0 390 844" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Flash POS amount entry screen</title>
+  <desc id="desc">A phone mockup showing the merchant keypad for entering a customer payment amount.</desc>
+  <rect width="390" height="844" rx="36" fill="#111"/>
+  <rect x="18" y="18" width="354" height="808" rx="28" fill="#fff"/>
+  <text x="195" y="78" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#202124">Pay to merchant</text>
+  <text x="195" y="150" text-anchor="middle" font-family="Arial, sans-serif" font-size="56" font-weight="700" fill="#202124">$12.50</text>
+  <text x="195" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#687076">Enter sale amount</text>
+  <rect x="54" y="222" width="282" height="46" rx="14" fill="#f3f5f7"/>
+  <text x="75" y="251" font-family="Arial, sans-serif" font-size="15" fill="#687076">Note</text>
+  <text x="300" y="251" text-anchor="end" font-family="Arial, sans-serif" font-size="15" fill="#202124">Coffee</text>
+  <g font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#202124" text-anchor="middle">
+    <text x="96" y="348">1</text><text x="195" y="348">2</text><text x="294" y="348">3</text>
+    <text x="96" y="432">4</text><text x="195" y="432">5</text><text x="294" y="432">6</text>
+    <text x="96" y="516">7</text><text x="195" y="516">8</text><text x="294" y="516">9</text>
+    <text x="96" y="600">.</text><text x="195" y="600">0</text><text x="294" y="600">del</text>
+  </g>
+  <rect x="36" y="670" width="144" height="56" rx="16" fill="#eef7f4"/>
+  <text x="108" y="704" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#007856">Give Points</text>
+  <rect x="210" y="670" width="144" height="56" rx="16" fill="#007856"/>
+  <text x="282" y="704" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#fff">Next</text>
+</svg>


### PR DESCRIPTION
## Summary
- Replaces the default React Native README with a Flash POS-specific project overview.
- Adds setup, local development, supported hardware, project structure, docs, and contributor guidance.
- Adds three lightweight SVG screenshots/reference visuals for the README.
- Adds a CONTRIBUTING guide with local workflow and PR checklist.

Closes #49.

## Validation
- Checked README relative links locally.
- Checked SVG files for valid opening/closing tags.
- Ran `git diff --check`.
- Ran `corepack yarn install --frozen-lockfile` successfully, then removed `node_modules`.

Existing project checks that were attempted but did not pass before/after this docs-only change:
- `corepack yarn test --runInBand` currently fails on existing test/dependency config issues (`rewardSlice`, missing `@testing-library/react-native`, and `react-redux` ESM transform).
- `corepack yarn lint` currently reports existing source lint errors unrelated to these README/docs changes.