### PR TITLE
docs: refresh AUDIT_REPORT.md for current main

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,199 +1,73 @@
-# Flash POS Code Audit Report
-## Commits: e0afb692..815578da
+# Flash POS — Audit Report
 
-## Executive Summary
+**Repo:** `lnflash/flash-pos` @ `main` (commit `31e0225` — "#59 invoice guard, native support chat, PIN performance, timer")
+**Date:** 2026-06-22
+**Stack:** React Native 0.77.1 · TypeScript · Redux Toolkit + Contexts · NFC flashcards · BTCPay/Lightning payouts
+**Method:** Four parallel deep-dives — security, architecture/code-quality, dependencies/build, tests/recent-work. Tests, typecheck, and lint were run locally.
 
-This audit examines the implementation of the Merchant Reward ID system and related enhancements in the Flash POS application. While the functionality improvements are significant, several critical security vulnerabilities and code quality issues need immediate attention before production deployment.
+> This report supersedes the previous audit (which targeted commit range `e0afb692..815578da`, the Merchant Rewards ID System v3 work). Most of that report's critical items have since been remediated — see "What's already good" below.
 
-## 🔴 Critical Security Issues
+## Overall verdict
 
-### 1. **Unvalidated User Input - Injection Risk**
-**Location**: `src/screens/RewardsSettings.tsx`
-```typescript
-// Line 237-238 - Direct user input used in URL without validation
-const response = await axios.get(
-  `${BTC_PAY_SERVER}/pull-payments/${merchantRewardId.trim()}`,
-);
-```
-**Risk**: Potential for URL injection attacks
-**Fix**: Implement proper input validation and sanitization
+**Solid and noticeably improving — not yet release-ready.** The team has already remediated nearly every "critical" item from the previous audit, the supply-chain posture is genuinely good, and recent #59 work is well-guarded and tested. The remaining material risks are **payment-flow integrity** (double-payout, NFC trust) and **process gaps** (CI broken on a clean checkout, core money paths untested) — not credential leaks.
 
-### 2. **Sensitive Data in Plain Text Storage**
-**Location**: `src/contexts/Flashcard.tsx`
-```typescript
-// Line 343-349 - LNURL stored unencrypted
-await AsyncStorage.setItem(
-  `flashcard_${scannedTag.id}`,
-  JSON.stringify({
-    id: scannedTag.id,
-    lnurl: extractedLnurl,
-    balance: storedBalance,
-  }),
-);
-```
-**Risk**: Exposed financial credentials if device is compromised
-**Fix**: Implement encryption using react-native-keychain or similar
+## ✅ What's already good
 
-### 3. **No Rate Limiting on Rewards**
-**Location**: `src/screens/Invoice.tsx`
-```typescript
-// Line 144-181 - No check for repeated reward attempts
-const sendRewardsToCard = useCallback(
-  async (cardLnurl: string, rewardAmount: number) => {
-    // Direct reward sending without rate limiting
-```
-**Risk**: Potential for reward system abuse
-**Fix**: Implement rate limiting and duplicate prevention
+- **Previous audit largely fixed:** merchant-ID input is now sanitized (`src/utils/validation.ts`); flashcard LNURL/balance and the PIN moved to **Keychain** (`src/services/secureStorage.ts`); PIN uses **PBKDF2-SHA256** with constant-time compare and iteration upgrade; reward numeric inputs are bounded (`src/utils/rewardCalculations.ts`).
+- **Supply chain:** no secrets/keystores committed; release signing **fails the build** if signing vars are missing (`android/app/build.gradle`); a `resolutions` block proactively pins past transitive CVEs (`lodash`, `ws`, `node-forge`, `shell-quote`, `picomatch`). `yarn audit`: **0 high/critical**.
+- **Native config correct:** iOS ATS enforced (`NSAllowsArbitraryLoads=false`), encryption-export flag set (`ITSAppUsesNonExemptEncryption=false`), scoped NFC/location usage strings; Android minimal permissions (`NFC` + `INTERNET`, `allowBackup=false`), SDK 35 / minSdk 24 / NDK 27, new-arch + Hermes.
+- **Tests:** 142 real-assertion tests across utils, slices, and services; clean typecheck and lint. The Invoice payment-confirmation suite (the #59 money-guard) is excellent — it covers PAID-but-confirm-pending, confirm errors, transient subscription errors, EXPIRED, and the "store only after network-only confirm" guard.
 
-## 🟡 High Priority Issues
+## 🔴 Top priorities (fix before production)
 
-### 1. **Extensive Debug Logging**
-Multiple files contain sensitive debug information:
-```typescript
-// src/contexts/Flashcard.tsx - Line 103
-console.log('=== HANDLETAG DEBUG ===');
-console.log('Current screen:', currentScreen);
-console.log('Tag ID:', scannedTag?.id);
+### 1. No idempotency / double-payout protection on BTCPay reward payouts — *High (money loss)*
+`src/screens/Invoice.tsx:130-137` and `src/screens/Rewards.tsx:237` POST to `…/api/v1/pull-payments/{id}/payouts` with **no idempotency key**. The `Invoice.tsx` reward path also has **no cooldown** (the 5s lock exists only in `Rewards.tsx`), and its only guard — `completedPaymentHashRef` (`Invoice.tsx:159-162`), in memory — does not survive a remount / app-resume / subscription re-fire, nor an axios retry on the POST. A reward can be issued twice.
 
-// src/screens/RewardsSettings.tsx - Line 238
-console.log('Testing Merchant Reward ID:', merchantRewardId.trim());
-console.log('Test response:', response.status, response.data);
-```
-**Risk**: Information disclosure in production
-**Fix**: Remove all console.log statements or use conditional logging
+**Fix:** send a deterministic idempotency key derived from `paymentHash` on the payout POST (BTCPay Greenfield supports this), and **persist** "reward already sent for paymentHash X" rather than relying on an in-memory ref.
 
-### 2. **Missing Error Boundaries**
-No error boundaries implemented for critical operations
-**Risk**: App crashes on unhandled errors
-**Fix**: Implement React error boundaries
+### 2. App trusts untrusted NFC tags for outbound requests and payout destination — *High (SSRF / fraud)*
+`src/contexts/Flashcard.tsx:207-230` (`getHtml`) builds a URL entirely from the scanned tag payload (`lnurlw://…` → `https://…`) with **no host allowlist**, then `axios.get`s it and scrapes the HTML for an LNURL (`src/utils/flashcardParser.ts`, which even matches a bare token) that later becomes a payout **destination**. A cloned/malicious card can point the POS at any attacker host and inject a destination the merchant then funds.
 
-### 3. **Synchronous Storage Operations**
-**Location**: `src/contexts/Flashcard.tsx`
-```typescript
-// Lines 471-477 - Synchronous getAllKeys operation
-const getAllStoredCards = useCallback(async () => {
-  const keys = await AsyncStorage.getAllKeys();
-  const flashcardKeys = keys.filter(key => key.startsWith('flashcard_'));
-```
-**Risk**: UI blocking on large datasets
-**Fix**: Implement pagination or lazy loading
+**Fix:** validate the rewritten URL host against an allowlist of known boltcard/Flash domains; require HTTPS; validate the decoded LNURL domain before using it as a payout destination.
 
-## 🟠 Medium Priority Issues
+### 3. CI is green only by accident — fails on a clean checkout — *High (process)*
+`.env` is gitignored and absent from the repo; `babel-plugin-dotenv-import` hard-fails at transform time without `REWARDS_ENABLED` / `BTC_PAY_SERVER`. The CI workflow (`.github/workflows/ci.yml`) never creates a `.env`, so **CI breaks on a fresh clone**. Verified locally: 6 suites fail without `.env`; after `cp .env.example .env`, all 18 suites / 142 tests pass.
 
-### 1. **Race Conditions**
-**Location**: `src/screens/Invoice.tsx`
-```typescript
-// Potential race condition between card storage and payment processing
-useEffect(() => {
-  if (data?.lnInvoicePaymentStatus?.status === 'PAID' && !paymentLoading) {
-    handleSuccessfulPayment();
-  }
-}, [data, paymentLoading]);
-```
+**Fix:** add a `cp .env.example .env` (or a CI-provided `.env`) step before lint/typecheck/test in `ci.yml`.
 
-### 2. **No Idempotency Keys**
-Reward transactions lack idempotency protection
-**Risk**: Duplicate rewards on network retries
-**Fix**: Implement unique transaction identifiers
+### 4. Core money paths have zero test coverage — *High (confidence)*
+Reward calculation is well tested, but the **orchestration** is not: `Flashcard.tsx` NFC read/balance/pay, `Invoice.sendRewardsToCard`, and `Rewards.onReward` payout flows — the three highest-risk money paths — are untested.
 
-### 3. **Missing Input Validation**
-```typescript
-// src/screens/RewardsSettings.tsx - Lines 263-269
-const handleRewardPercentageChange = (value: string) => {
-  setRewardPercentage(value);
-  const numValue = parseFloat(value);
-  // No validation for negative numbers or extreme values
-};
-```
+**Fix:** add integration tests for these three before further feature work. Also add `requestTechnology` / `getTag` to the NFC mock in `jest.setup.js` (currently missing, which will break any test importing the new `readFlashcard` util).
 
-## ✅ Positive Findings
+## 🟠 Medium
 
-1. **Well-Structured State Management**
-   - Clean Redux implementation with proper selectors
-   - Good separation of concerns
+- **Hardcoded Chatwoot widget token** (`src/services/chatwoot/config.ts:11`), passed as a URL query param (`api.ts:28`). It is a *public* widget token (low blast radius — can create/spam support conversations, not read other tenants), but it should be rotated and moved to `@env` like the other endpoints; prefer header/body over query string.
+- **PIN has no attempt lockout / throttling** (`src/store/slices/pinSlice.ts:125-169`). Hashing is strong, but guesses are unlimited. Add a persisted failed-attempt counter with exponential backoff / temporary lockout; consider raising PBKDF2 iterations (≥100k) for a money app.
+- **Pervasive silent error-swallowing** on NFC / axios / payment / storage paths — empty `catch {}` / `else {}` in `Flashcard.tsx` (`196`, `256-260`, `299`), `Invoice.tsx:371`, `amountSlice.ts:125`, `ApolloClient.ts:58`, and several services. Failed scans/payments produce no log and no user feedback. Route through a central logger + user-facing toast.
+- **Business logic trapped in 100-200-line screen callbacks:** `Rewards.onReward` (~200 lines, 20+ dep array), `Invoice.handleSuccessfulPayment` (~100 lines), `Keypad.onCreateInvoice`. Merchant-ID validation is duplicated across `EventSettings`, `RewardsSettings`, `Rewards`, and `Invoice`. Extract into hooks (`useRewardRedemption`, `useInvoicePayment`).
+- **`src/store/slices/rewardSlice.ts` is a 611-line god-slice** mixing reward config, event config, and live tracking, with ~40 `(state: any)` selectors and a ~130-line duplicated default-config block. Split into config/event/tracking; type selectors with `RootState` (as `pinSlice.ts` already does).
+- **Dual source of truth:** flashcard/payment state and the "loading" concept are split across Redux, an **unmemoized** `FlashcardContext` (`Flashcard.tsx:341-358` rebuilds `value` every render → re-renders the whole app), and `ActivityIndicatorContext`. Consolidate; memoize context values.
+- **Build-toolchain advisories** (8 moderate: `js-yaml`, `@babel/core`) — dev/build-time only, not shipped. Clear via `resolutions` and re-audit.
+- **TypeScript pinned to `5.0.4`** (RN 0.77 expects ~5.3+); **no `.nvmrc`/JDK-17 pin** (CI uses Node 20, `engines` says `>=18`); **CI is test-only** — no native build job, no scheduled `yarn audit`, and lint runs `--max-warnings 99999`.
 
-2. **Responsive Design Implementation**
-   - Proper scaling for different device sizes
-   - Good use of responsive units
+## 🟡 Low (quick wins)
 
-3. **Backward Compatibility**
-   - Environment variable fallbacks maintained
-   - Graceful degradation for missing features
+- `src/screens/Rewards.tsx:201` — a *failed* reward still consumes the 5s cooldown (`lastRewardTime` is set before the payout). Set it only inside the success branch.
+- `src/utils/transactionHelpers.ts` — IDs/timestamps from `Date.now()` in rapid succession risk collisions in POS use. Use a UUID.
+- New `src/utils/flashcard.tsx` (`readFlashcard`, iOS NFC util) has **invisible Unicode characters** in its `Alert` string (line ~31) and is not covered by the NFC mock.
+- ~10 stray `console.*` in production paths; 10 TODO/FIXME (notably unfinished Apollo WS reconnection in `ApolloClient.ts:30,41`); 210 hardcoded hex colors with no theme file; payment `paymentSecret` retained in plaintext AsyncStorage transaction history (`store/index.ts`, `Invoice.tsx:219`).
+- The 3 `patch-package` patches (`react-native-svg`, `react-native-screens`, `react-native-print`) are legitimate RN-0.77 compat shims. Track the `react-native-screens` one for removal once upstream fixes the regression.
+- Jest prints "did not exit one second after the test run" — an unclosed async handle (likely a chatwoot socket/timer). Investigate with `--detectOpenHandles`.
 
-4. **User Experience Improvements**
-   - Auto-save functionality
-   - Real-time validation feedback
-   - Clear error messages
+## Recommended order
 
-## 📋 Recommendations
+1. **Idempotency + persistent reward-sent guard** (#1) — highest money risk.
+2. **NFC host / LNURL allowlist** (#2).
+3. **Fix CI `.env`** (#3) — one line; unblocks trustworthy CI.
+4. **Tests for the three untested money paths** (#4).
+5. Then the Medium cluster — error handling, Chatwoot token rotation, PIN lockout, `rewardSlice` split, TS/CI tooling.
 
-### Immediate Actions (Before Production)
+---
 
-1. **Security Fixes**
-   ```typescript
-   // Add input validation
-   const validateMerchantId = (id: string): boolean => {
-     const sanitized = id.trim();
-     return /^[a-zA-Z0-9-_]+$/.test(sanitized) && sanitized.length <= 100;
-   };
-   
-   // Encrypt sensitive data
-   import * as Keychain from 'react-native-keychain';
-   
-   const storeSecureCard = async (cardId: string, data: any) => {
-     await Keychain.setInternetCredentials(
-       `flashcard_${cardId}`,
-       'flashcard',
-       JSON.stringify(data)
-     );
-   };
-   ```
-
-2. **Remove Debug Logging**
-   ```typescript
-   // Replace with conditional logging
-   const debugLog = (...args: any[]) => {
-     if (__DEV__) {
-       console.log(...args);
-     }
-   };
-   ```
-
-3. **Implement Rate Limiting**
-   ```typescript
-   const rewardAttempts = new Map<string, number>();
-   
-   const canSendReward = (cardId: string): boolean => {
-     const lastAttempt = rewardAttempts.get(cardId) || 0;
-     const now = Date.now();
-     if (now - lastAttempt < 60000) { // 1 minute cooldown
-       return false;
-     }
-     rewardAttempts.set(cardId, now);
-     return true;
-   };
-   ```
-
-### Medium-term Improvements
-
-1. **Add Comprehensive Testing**
-   - Unit tests for reward calculations
-   - Integration tests for NFC flows
-   - End-to-end tests for critical paths
-
-2. **Implement Monitoring**
-   - Error tracking (Sentry/Bugsnag)
-   - Performance monitoring
-   - Analytics for reward usage
-
-3. **Code Quality**
-   - Extract magic numbers to constants
-   - Add proper TypeScript types for all API responses
-   - Implement proper error boundaries
-
-## Conclusion
-
-The rewards system v3 implementation adds valuable functionality to the Flash POS application. However, the security vulnerabilities identified must be addressed before production deployment. The code quality is generally good, with room for improvement in error handling and performance optimization.
-
-**Overall Risk Assessment**: HIGH - Due to security vulnerabilities
-**Recommended Action**: Fix critical security issues before deployment
+*Audit generated with Claude Code.*


### PR DESCRIPTION
## Summary

Replaces the stale `AUDIT_REPORT.md` (which targeted commit range `e0afb692..815578da`, the Merchant Rewards ID System v3 work) with a **fresh audit of current `main`** (`31e0225`).

The refresh was produced from four parallel deep-dives — security, architecture/code-quality, dependencies/build, and tests/recent-work — with tests, typecheck, and lint run locally.

## Headline

**Solid and improving — not yet release-ready.** Most prior "critical" items are now **remediated** (input sanitization, Keychain-backed flashcard/PIN storage, PBKDF2 PIN hashing). The current report reframes around what actually remains:

**Top priorities (before production):**
1. 🔴 **No idempotency on BTCPay reward payouts** + `Invoice.tsx` lacks the cooldown `Rewards.tsx` has → real double-payout risk.
2. 🔴 **Untrusted NFC tags drive outbound requests + payout destination** (no host/LNURL allowlist) → SSRF/fraud.
3. 🔴 **CI is green only by accident** — fails on a clean checkout because no `.env` is created (verified locally).
4. 🔴 **Core money paths untested** — Flashcard NFC orchestration and both reward-payout flows.

Plus a Medium cluster (silent error-swallowing, business logic in screen callbacks, 611-line `rewardSlice`, dual state source-of-truth, TS/CI tooling) and Low quick wins.

## Note

Docs-only change — no source or behavior modified. Full detail (with `file:line` citations and a recommended fix order) is in the updated `AUDIT_REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)