### PR TITLE
ci: provision .env before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
+      - name: Provision .env for tests
+        run: cp .env.example .env
+
       - name: Test
         run: yarn test --runInBand


### PR DESCRIPTION
## Problem
The `test` CI job has been failing on `main` (and thus on every open PR, including #61) with:
```
SyntaxError: "REWARDS_ENABLED" is not defined in .env
SyntaxError: "BTC_PAY_SERVER" is not defined in .env
```

## Root cause
`babel.config.js` uses the `dotenv-import` plugin (`moduleName: '@env'`, `path: '.env'`), which validates every `@env` import against `.env` **at transform time**. `.env` is gitignored (`.gitignore:77`) and `ci.yml` never created one, so when `yarn test` runs jest → babel, the transform throws on the first `@env` import (e.g. `src/utils/featureFlags.ts`).

Lint and typecheck pass because they don't run the babel dotenv transform — only jest does, which is why `test` was the sole red check.

## Fix
Copy `.env.example` → `.env` before the test step. Verified `.env.example` already defines **all 6** `@env` vars used across `src/` (BTC_PAY_SERVER, FLASH_GRAPHQL_URI, FLASH_GRAPHQL_WS_URI, FLASH_LN_ADDRESS, FLASH_LN_ADDRESS_URL, REWARDS_ENABLED), so a single copy fully satisfies the plugin.

Independent of any feature work — this unblocks the `test` check for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)