### PR TITLE
ci: provide WebSocket polyfill for tests on Node 20

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,11 @@
 import 'react-native-gesture-handler/jestSetup';
 
+// CI runs Node 20, which has no global WebSocket. graphql-ws's createClient
+// needs one at module load (src/graphql/ApolloClient.ts), so App.test.tsx
+// (which imports App) fails to run. Node 22+ provides it globally, masking
+// this locally. `ws` is already a dependency.
+global.WebSocket = require('ws');
+
 /* global jest */
 
 jest.mock('@rneui/themed', () => {


### PR DESCRIPTION
## Problem
After #62 fixed the `.env` provisioning, the `test` job still failed on one suite — `__tests__/App.test.tsx`:
```
WebSocket implementation missing; on Node you can `import WebSocket from 'ws'` …
  at createClient (graphql-ws)  ← src/graphql/ApolloClient.ts:21  ← App.tsx  ← App.test.tsx
```

## Root cause — a Node-version trap
`ApolloClient.ts` eagerly calls `graphql-ws` `createClient` at module load, which needs a `WebSocket` implementation. **CI pins Node 20**, where `typeof WebSocket === "undefined"`, so it throws and the suite fails to run. **Node 22+ exposes `WebSocket` as a global**, which is why the failure is invisible in local dev (and why it looked like #62 should have been enough).

Confirmed both ways: under Node 24 the suite passes; nvm'd to Node 20 (CI's version) it reproduces the exact error.

## Fix
`ws` is already a dependency (`7.5.11`) and `jest.setup.js` already exists, so alias it onto `global.WebSocket`. Version-agnostic and minimal (vs. bumping CI's Node, which has broader ripple effects).

## Verification
Applied locally, switched Node to **20** (matching CI), ran the full suite:
```
Test Suites: 18 passed, 18 total
Tests:       142 passed, 142 total
```

Together with #62 this takes the `test` check fully green on `main` and every open PR (incl. #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)