### PR TITLE
fix(sales): refund-aware sales accounting — groundwork for #46

### DIFF
--- a/__tests__/hooks/usePrint.test.tsx
+++ b/__tests__/hooks/usePrint.test.tsx
@@ -1,0 +1,120 @@
+import {NativeModules} from 'react-native';
+import RNPrint from 'react-native-print';
+
+const printerMock = {
+  setAlignment: jest.fn(),
+  setTextBold: jest.fn(),
+  printText: jest.fn(),
+  printQRCode: jest.fn(),
+  nextLine: jest.fn(),
+};
+NativeModules.PrinterModule = printerMock;
+
+jest.mock('react-native-print', () => ({
+  __esModule: true,
+  default: {print: jest.fn()},
+}));
+
+const mockState = {
+  user: {username: 'merchant'},
+  amount: {
+    satAmount: 800,
+    displayAmount: '8.00',
+    currency: {
+      id: 'USD',
+      symbol: '$',
+      name: 'US Dollar',
+      flag: '🇺🇸',
+      fractionDigits: 2,
+    },
+    memo: '',
+  },
+};
+
+jest.mock('../../src/store/hooks', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector(mockState),
+}));
+
+// PrinterModule is destructured at module load — require after the mock is set
+const usePrint = require('../../src/hooks/usePrint').default;
+
+const baseReceipt: ReceiptData = {
+  id: 'tx_1',
+  timestamp: '2026-08-11T12:00:00.000Z',
+  satAmount: 800,
+  displayAmount: '8.00',
+  currency: {
+    id: 'USD',
+    symbol: '$',
+    name: 'US Dollar',
+    flag: '🇺🇸',
+    fractionDigits: 2,
+  },
+  isPrimaryAmountSats: false,
+  username: 'merchant',
+  memo: 'coffee',
+  paymentHash: 'hash',
+  status: 'Paid',
+  transactionType: 'lightning',
+};
+
+describe('usePrint receipt headlines', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('printReceipt prints "Sale completed" for a sale', () => {
+    const {printReceipt} = usePrint();
+    printReceipt(baseReceipt);
+    expect(printerMock.printText).toHaveBeenNthCalledWith(
+      1,
+      'Sale completed\n',
+    );
+  });
+
+  it('printReceipt prints "Refund completed" for a refund', () => {
+    const {printReceipt} = usePrint();
+    printReceipt({
+      ...baseReceipt,
+      transactionType: 'refund',
+      satAmount: -800,
+      displayAmount: '-8.00',
+    });
+    expect(printerMock.printText).toHaveBeenNthCalledWith(
+      1,
+      'Refund completed\n',
+    );
+    expect(printerMock.printText).not.toHaveBeenCalledWith('Sale completed\n');
+  });
+
+  it('printReceipt defaults to "Sale completed" when transactionType is absent', () => {
+    const {printReceipt} = usePrint();
+    printReceipt({...baseReceipt, transactionType: undefined});
+    expect(printerMock.printText).toHaveBeenNthCalledWith(
+      1,
+      'Sale completed\n',
+    );
+  });
+
+  it('printReceiptHTML renders "Refund completed" for a refund', async () => {
+    const {printReceiptHTML} = usePrint();
+    await printReceiptHTML({
+      ...baseReceipt,
+      transactionType: 'refund',
+      satAmount: -800,
+      displayAmount: '-8.00',
+    });
+    const html = (RNPrint.print as jest.Mock).mock.calls[0][0].html;
+    expect(html).toContain('Refund completed');
+    expect(html).not.toContain('Sale completed');
+  });
+
+  it('printReceiptHTML renders "Sale completed" for a sale', async () => {
+    const {printReceiptHTML} = usePrint();
+    await printReceiptHTML(baseReceipt);
+    const html = (RNPrint.print as jest.Mock).mock.calls[0][0].html;
+    expect(html).toContain('Sale completed');
+    expect(html).not.toContain('Refund completed');
+  });
+});

--- a/__tests__/screens/TransactionHistory.test.tsx
+++ b/__tests__/screens/TransactionHistory.test.tsx
@@ -94,10 +94,43 @@ describe('TransactionHistory Screen', () => {
     );
 
     expect(getByText('Transaction History')).toBeTruthy();
-    expect(getByText('1 transactions')).toBeTruthy();
+    expect(getByText(/1 transactions/)).toBeTruthy();
+    expect(getByText(/1000 points in sales/)).toBeTruthy();
     expect(getByText('$ 10.00')).toBeTruthy();
     expect(getByText('to testmerchant')).toBeTruthy();
     expect(getAllByText(/Lightning/).length).toBeGreaterThan(0);
+  });
+
+  it('should deduct refunds from the sales total in the header (issue #64)', () => {
+    const mockRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-1',
+      transactionType: 'refund',
+      refundOf: mockTransaction.id,
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: -400,
+        displayAmount: '4.00',
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [mockRefund, mockTransaction],
+        lastTransaction: mockRefund,
+        maxTransactions: 50,
+      },
+    };
+
+    const {getByText, getAllByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    // 1000 sale - 400 refund = 600, NOT 1400
+    expect(getByText(/600 points in sales/)).toBeTruthy();
+    expect(getAllByText(/Refund/).length).toBeGreaterThan(0);
   });
 
   it('should display transaction with sats as primary amount', () => {

--- a/__tests__/screens/TransactionHistory.test.tsx
+++ b/__tests__/screens/TransactionHistory.test.tsx
@@ -32,14 +32,15 @@ const createTestStore = (initialState = {}) => {
   });
 };
 
-const renderWithProviders = (component: React.ReactElement, initialState = {}) => {
+const renderWithProviders = (
+  component: React.ReactElement,
+  initialState = {},
+) => {
   const store = createTestStore(initialState);
   return render(
     <Provider store={store}>
-      <NavigationContainer>
-        {component}
-      </NavigationContainer>
-    </Provider>
+      <NavigationContainer>{component}</NavigationContainer>
+    </Provider>,
   );
 };
 
@@ -131,6 +132,107 @@ describe('TransactionHistory Screen', () => {
     // 1000 sale - 400 refund = 600, NOT 1400
     expect(getByText(/600 points in sales/)).toBeTruthy();
     expect(getAllByText(/Refund/).length).toBeGreaterThan(0);
+  });
+
+  it('should render a fiat-primary refund with a minus sign, not like a sale', () => {
+    const mockRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-1',
+      transactionType: 'refund',
+      refundOf: mockTransaction.id,
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: -400,
+        displayAmount: '4.00',
+        isPrimaryAmountSats: false,
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [mockRefund, mockTransaction],
+        lastTransaction: mockRefund,
+        maxTransactions: 50,
+      },
+    };
+
+    const {getByText, queryByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    expect(getByText('-$ 4.00')).toBeTruthy();
+    expect(queryByText('$ 4.00')).toBeNull();
+    // The sale keeps its unsigned rendering
+    expect(getByText('$ 10.00')).toBeTruthy();
+  });
+
+  it('should offer a Refunds filter chip that shows only refund rows', () => {
+    const mockRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-1',
+      transactionType: 'refund',
+      refundOf: mockTransaction.id,
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: -400,
+        displayAmount: '4.00',
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [mockRefund, mockTransaction],
+        lastTransaction: mockRefund,
+        maxTransactions: 50,
+      },
+    };
+
+    const {getByText, queryByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    const refundChip = getByText(/Refunds \(1\)/);
+    expect(refundChip).toBeTruthy();
+
+    fireEvent.press(refundChip);
+
+    // Refund row stays, sale row is filtered out
+    expect(getByText('-$ 4.00')).toBeTruthy();
+    expect(queryByText('$ 10.00')).toBeNull();
+  });
+
+  it('should not count a zero-amount reward in the With Rewards chip', () => {
+    const zeroRewardTransaction: TransactionData = {
+      ...mockTransaction,
+      reward: {
+        rewardAmount: 0,
+        rewardRate: 0.02,
+        wasMinimumApplied: false,
+        wasMaximumApplied: false,
+        isStandalone: false,
+        timestamp: '2024-01-01T12:00:00Z',
+      },
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [zeroRewardTransaction],
+        lastTransaction: zeroRewardTransaction,
+        maxTransactions: 50,
+      },
+    };
+
+    const {queryByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    // Statistics come from selectTransactionStatistics, which only counts
+    // rewards with rewardAmount > 0 — the chip must agree with it.
+    expect(queryByText(/With Rewards/)).toBeNull();
   });
 
   it('should display transaction with sats as primary amount', () => {

--- a/__tests__/screens/TransactionHistory.test.tsx
+++ b/__tests__/screens/TransactionHistory.test.tsx
@@ -12,11 +12,13 @@ import invoiceSlice from '../../src/store/slices/invoiceSlice';
 
 const TransactionHistoryScreen = TransactionHistory as React.ComponentType;
 
-// Mock the usePrint hook
+// Mock the usePrint hook — capture printReceipt calls so tests can assert
+// on the exact ReceiptData the screen hands to the printer
+const mockPrintReceipt = jest.fn();
 jest.mock('../../src/hooks/usePrint', () => ({
   __esModule: true,
   default: () => ({
-    printReceipt: jest.fn(),
+    printReceipt: mockPrintReceipt,
   }),
 }));
 
@@ -73,6 +75,10 @@ const mockTransaction: TransactionData = {
 };
 
 describe('TransactionHistory Screen', () => {
+  beforeEach(() => {
+    mockPrintReceipt.mockClear();
+  });
+
   it('should render empty state when no transactions', () => {
     const {getByText} = renderWithProviders(<TransactionHistoryScreen />);
 
@@ -294,8 +300,99 @@ describe('TransactionHistory Screen', () => {
     const reprintButton = getByText('Reprint');
     fireEvent.press(reprintButton);
 
-    // The print function should be called (mocked in this test)
-    expect(reprintButton).toBeTruthy();
+    // A sale reprints with its amounts exactly as stored — unsigned
+    expect(mockPrintReceipt).toHaveBeenCalledTimes(1);
+    expect(mockPrintReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        satAmount: 1000,
+        displayAmount: '10.00',
+        transactionType: 'lightning',
+      }),
+    );
+  });
+
+  it('should reprint a refund with signed amounts, never like a sale receipt', () => {
+    const mockRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-1',
+      transactionType: 'refund',
+      refundOf: mockTransaction.id,
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: -800,
+        displayAmount: '8.00',
+        isPrimaryAmountSats: false,
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [mockRefund],
+        lastTransaction: mockRefund,
+        maxTransactions: 50,
+      },
+    };
+
+    const {getByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    fireEvent.press(getByText('Reprint'));
+
+    // The receipt fiat must carry the sign — '$ 8.00' on paper would be
+    // indistinguishable from a sale receipt
+    expect(mockPrintReceipt).toHaveBeenCalledTimes(1);
+    expect(mockPrintReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        satAmount: -800,
+        displayAmount: '-8.00',
+        transactionType: 'refund',
+      }),
+    );
+  });
+
+  it('should reprint a positive-stored refund with signed amounts (issue #64)', () => {
+    // Legacy rows persisted before refund-sign normalization can still carry
+    // a positive amount — the receipt must sign them anyway
+    const legacyRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-legacy',
+      transactionType: 'refund',
+      refundOf: mockTransaction.id,
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: 800,
+        displayAmount: '8.00',
+        isPrimaryAmountSats: false,
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+    const initialState = {
+      transactionHistory: {
+        transactions: [legacyRefund],
+        lastTransaction: legacyRefund,
+        maxTransactions: 50,
+      },
+    };
+
+    const {getByText} = renderWithProviders(
+      <TransactionHistoryScreen />,
+      initialState,
+    );
+
+    fireEvent.press(getByText('Reprint'));
+
+    expect(mockPrintReceipt).toHaveBeenCalledTimes(1);
+    expect(mockPrintReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        satAmount: -800,
+        displayAmount: '-8.00',
+        transactionType: 'refund',
+      }),
+    );
   });
 
   it('should show clear history button when transactions exist', () => {

--- a/__tests__/store/transactionHistorySlice.test.ts
+++ b/__tests__/store/transactionHistorySlice.test.ts
@@ -57,7 +57,10 @@ describe('transactionHistorySlice', () => {
     });
 
     it('should not set lastTransaction when status is not completed', () => {
-      const pendingTransaction = {...mockTransaction, status: 'pending' as const};
+      const pendingTransaction = {
+        ...mockTransaction,
+        status: 'pending' as const,
+      };
       store.dispatch(addTransaction(pendingTransaction));
 
       const state = store.getState();
@@ -65,8 +68,16 @@ describe('transactionHistorySlice', () => {
     });
 
     it('should maintain transactions in chronological order (newest first)', () => {
-      const transaction1 = {...mockTransaction, id: 'tx-1', timestamp: '2024-01-01T12:00:00Z'};
-      const transaction2 = {...mockTransaction, id: 'tx-2', timestamp: '2024-01-01T13:00:00Z'};
+      const transaction1 = {
+        ...mockTransaction,
+        id: 'tx-1',
+        timestamp: '2024-01-01T12:00:00Z',
+      };
+      const transaction2 = {
+        ...mockTransaction,
+        id: 'tx-2',
+        timestamp: '2024-01-01T13:00:00Z',
+      };
 
       store.dispatch(addTransaction(transaction1));
       store.dispatch(addTransaction(transaction2));
@@ -86,25 +97,116 @@ describe('transactionHistorySlice', () => {
       const state = store.getState();
       expect(state.transactionHistory.transactions).toHaveLength(50);
     });
+
+    it('should drop a transaction that fails validation instead of recording it', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const invalidTransaction = {
+        ...mockTransaction,
+        merchant: {username: ''},
+      };
+
+      store.dispatch(addTransaction(invalidTransaction));
+
+      const state = store.getState();
+      expect(state.transactionHistory.transactions).toHaveLength(0);
+      expect(state.transactionHistory.lastTransaction).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should drop a zero-amount refund', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      store.dispatch(
+        addTransaction({
+          ...mockTransaction,
+          id: 'refund-zero',
+          transactionType: 'refund',
+          amount: {...mockTransaction.amount, satAmount: 0},
+          invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+        }),
+      );
+
+      const state = store.getState();
+      expect(state.transactionHistory.transactions).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+
+    it('should normalize a positive-stored refund to a negative amount (issue #64)', () => {
+      store.dispatch(
+        addTransaction({
+          ...mockTransaction,
+          id: 'refund-positive',
+          transactionType: 'refund',
+          refundOf: mockTransaction.id,
+          amount: {...mockTransaction.amount, satAmount: 400},
+          invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+        }),
+      );
+
+      const state = store.getState();
+      expect(state.transactionHistory.transactions).toHaveLength(1);
+      expect(state.transactionHistory.transactions[0].amount.satAmount).toBe(
+        -400,
+      );
+    });
+
+    it('should record the zero-amount rewards-only shape dispatched for NFC card taps', () => {
+      // The Rewards screen records standalone NFC taps as rewards-only with
+      // satAmount 0 — the validation gate must not drop this real flow.
+      store.dispatch(
+        addTransaction({
+          ...mockTransaction,
+          id: 'nfc-tap-1',
+          transactionType: 'rewards-only',
+          paymentMethod: 'lightning',
+          amount: {...mockTransaction.amount, satAmount: 0},
+          invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+          reward: {
+            rewardAmount: 21,
+            rewardRate: 0.02,
+            wasMinimumApplied: false,
+            wasMaximumApplied: false,
+            isStandalone: true,
+            timestamp: '2024-01-01T12:00:00Z',
+          },
+        }),
+      );
+
+      const state = store.getState();
+      expect(state.transactionHistory.transactions).toHaveLength(1);
+      expect(state.transactionHistory.transactions[0].id).toBe('nfc-tap-1');
+    });
   });
 
   describe('updateTransactionStatus', () => {
     it('should update transaction status', () => {
-      const pendingTransaction = {...mockTransaction, status: 'pending' as const};
+      const pendingTransaction = {
+        ...mockTransaction,
+        status: 'pending' as const,
+      };
       store.dispatch(addTransaction(pendingTransaction));
-      store.dispatch(updateTransactionStatus({id: mockTransaction.id, status: 'completed'}));
+      store.dispatch(
+        updateTransactionStatus({id: mockTransaction.id, status: 'completed'}),
+      );
 
       const state = store.getState();
       expect(state.transactionHistory.transactions[0].status).toBe('completed');
     });
 
     it('should update lastTransaction when status becomes completed', () => {
-      const pendingTransaction = {...mockTransaction, status: 'pending' as const};
+      const pendingTransaction = {
+        ...mockTransaction,
+        status: 'pending' as const,
+      };
       store.dispatch(addTransaction(pendingTransaction));
-      store.dispatch(updateTransactionStatus({id: mockTransaction.id, status: 'completed'}));
+      store.dispatch(
+        updateTransactionStatus({id: mockTransaction.id, status: 'completed'}),
+      );
 
       const state = store.getState();
-      expect(state.transactionHistory.lastTransaction?.id).toBe(mockTransaction.id);
+      expect(state.transactionHistory.lastTransaction?.id).toBe(
+        mockTransaction.id,
+      );
     });
   });
 

--- a/__tests__/store/transactionHistorySlice.test.ts
+++ b/__tests__/store/transactionHistorySlice.test.ts
@@ -4,6 +4,7 @@ import {
   updateTransactionStatus,
   clearTransactionHistory,
   removeTransaction,
+  selectTransactionStatistics,
 } from '../../src/store/slices/transactionHistorySlice';
 
 describe('transactionHistorySlice', () => {
@@ -137,6 +138,62 @@ describe('transactionHistorySlice', () => {
       const state = store.getState();
       expect(state.transactionHistory.transactions).toHaveLength(0);
       expect(state.transactionHistory.lastTransaction).toBeUndefined();
+    });
+  });
+
+  describe('selectTransactionStatistics — sales total (issue #64)', () => {
+    const mockRefund: TransactionData = {
+      ...mockTransaction,
+      id: 'refund-tx-1',
+      transactionType: 'refund',
+      refundOf: 'test-tx-1',
+      amount: {
+        ...mockTransaction.amount,
+        satAmount: -400,
+        displayAmount: '4.00',
+      },
+      invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+      memo: 'Refund',
+    };
+
+    it('sums sale amounts when there are only sales', () => {
+      store.dispatch(addTransaction({...mockTransaction, id: 'sale-1'}));
+      store.dispatch(addTransaction({...mockTransaction, id: 'sale-2'}));
+
+      const stats = selectTransactionStatistics(store.getState());
+      expect(stats.totalSales).toBe(2000);
+      expect(stats.refundCount).toBe(0);
+    });
+
+    it('deducts a refund from the sales total instead of adding it', () => {
+      store.dispatch(addTransaction({...mockTransaction, id: 'sale-1'}));
+      store.dispatch(addTransaction(mockRefund));
+
+      const stats = selectTransactionStatistics(store.getState());
+      expect(stats.totalSales).toBe(600); // 1000 sale - 400 refund
+      expect(stats.refundCount).toBe(1);
+    });
+
+    it('returns a negative total when history contains only a refund', () => {
+      store.dispatch(addTransaction(mockRefund));
+
+      const stats = selectTransactionStatistics(store.getState());
+      expect(stats.totalSales).toBe(-400);
+      expect(stats.refundCount).toBe(1);
+      expect(stats.totalTransactions).toBe(1);
+    });
+
+    it('deducts a refund even if it was stored with a positive amount', () => {
+      store.dispatch(addTransaction({...mockTransaction, id: 'sale-1'}));
+      store.dispatch(
+        addTransaction({
+          ...mockRefund,
+          amount: {...mockRefund.amount, satAmount: 400},
+        }),
+      );
+
+      const stats = selectTransactionStatistics(store.getState());
+      expect(stats.totalSales).toBe(600);
     });
   });
 });

--- a/__tests__/utils/transactionHelpers.test.ts
+++ b/__tests__/utils/transactionHelpers.test.ts
@@ -3,6 +3,7 @@ import {
   getSalesContribution,
   createRefundTransaction,
   formatTransactionAmount,
+  getReceiptAmounts,
   validateTransactionData,
 } from '../../src/utils/transactionHelpers';
 
@@ -217,6 +218,72 @@ describe('formatTransactionAmount', () => {
     });
 
     expect(formatTransactionAmount(refund)).toBe('-$ 8.00');
+  });
+});
+
+describe('getReceiptAmounts', () => {
+  it('passes sale amounts through as stored', () => {
+    const sale = makeSale('s1', 1000, {
+      amount: {
+        satAmount: 1000,
+        displayAmount: '10.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(getReceiptAmounts(sale)).toEqual({
+      satAmount: 1000,
+      displayAmount: '10.00',
+    });
+  });
+
+  it('signs both amounts for a refund stored negative sats / unsigned fiat', () => {
+    const refund = makeRefund('r1', -800, {
+      amount: {
+        satAmount: -800,
+        displayAmount: '8.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(getReceiptAmounts(refund)).toEqual({
+      satAmount: -800,
+      displayAmount: '-8.00',
+    });
+  });
+
+  it('signs both amounts for a refund stored positive (issue #64)', () => {
+    const refund = makeRefund('r1', 800, {
+      amount: {
+        satAmount: 800,
+        displayAmount: '8.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(getReceiptAmounts(refund)).toEqual({
+      satAmount: -800,
+      displayAmount: '-8.00',
+    });
+  });
+
+  it('does not double the sign when a refund displayAmount is already negative', () => {
+    const refund = makeRefund('r1', -800, {
+      amount: {
+        satAmount: -800,
+        displayAmount: '-8.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(getReceiptAmounts(refund)).toEqual({
+      satAmount: -800,
+      displayAmount: '-8.00',
+    });
   });
 });
 

--- a/__tests__/utils/transactionHelpers.test.ts
+++ b/__tests__/utils/transactionHelpers.test.ts
@@ -2,6 +2,7 @@ import {
   calculateSalesTotal,
   getSalesContribution,
   createRefundTransaction,
+  formatTransactionAmount,
   validateTransactionData,
 } from '../../src/utils/transactionHelpers';
 
@@ -166,6 +167,59 @@ describe('createRefundTransaction', () => {
   });
 });
 
+describe('formatTransactionAmount', () => {
+  it('renders a sats-primary sale as stored', () => {
+    expect(formatTransactionAmount(makeSale('s1', 1000))).toBe('1000 points');
+  });
+
+  it('renders a fiat-primary sale as stored', () => {
+    const sale = makeSale('s1', 1000, {
+      amount: {
+        satAmount: 1000,
+        displayAmount: '10.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(formatTransactionAmount(sale)).toBe('$ 10.00');
+  });
+
+  it('renders a sats-primary refund negative', () => {
+    expect(formatTransactionAmount(makeRefund('r1', -400))).toBe('-400 points');
+  });
+
+  it('renders a sats-primary refund negative even when stored positive (issue #64)', () => {
+    expect(formatTransactionAmount(makeRefund('r1', 400))).toBe('-400 points');
+  });
+
+  it('renders a fiat-primary refund with a minus sign', () => {
+    const refund = makeRefund('r1', -800, {
+      amount: {
+        satAmount: -800,
+        displayAmount: '8.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(formatTransactionAmount(refund)).toBe('-$ 8.00');
+  });
+
+  it('does not double the sign when a refund displayAmount is already negative', () => {
+    const refund = makeRefund('r1', -800, {
+      amount: {
+        satAmount: -800,
+        displayAmount: '-8.00',
+        currency: usd,
+        isPrimaryAmountSats: false,
+      },
+    });
+
+    expect(formatTransactionAmount(refund)).toBe('-$ 8.00');
+  });
+});
+
 describe('validateTransactionData (refunds)', () => {
   it('accepts a refund with a negative amount', () => {
     const result = validateTransactionData(makeRefund('r1', -500));
@@ -201,5 +255,36 @@ describe('validateTransactionData (refunds)', () => {
     const result = validateTransactionData(makeSale('s1', 100));
 
     expect(result.isValid).toBe(true);
+  });
+
+  it('accepts the zero-amount rewards-only shape the Rewards screen records for NFC taps', () => {
+    const nfcTap = makeSale('nfc-1', 0, {
+      transactionType: 'rewards-only',
+      paymentMethod: 'lightning',
+      reward: {
+        rewardAmount: 21,
+        rewardRate: 0.02,
+        wasMinimumApplied: false,
+        wasMaximumApplied: false,
+        isStandalone: true,
+        timestamp: '2024-01-01T12:00:00Z',
+      },
+    });
+
+    expect(validateTransactionData(nfcTap)).toEqual({
+      isValid: true,
+      errors: [],
+    });
+  });
+
+  it('still rejects a zero-amount rewards-only transaction without a reward', () => {
+    const result = validateTransactionData(
+      makeSale('s1', 0, {
+        transactionType: 'rewards-only',
+        paymentMethod: 'card',
+      }),
+    );
+
+    expect(result.isValid).toBe(false);
   });
 });

--- a/__tests__/utils/transactionHelpers.test.ts
+++ b/__tests__/utils/transactionHelpers.test.ts
@@ -1,0 +1,205 @@
+import {
+  calculateSalesTotal,
+  getSalesContribution,
+  createRefundTransaction,
+  validateTransactionData,
+} from '../../src/utils/transactionHelpers';
+
+const usd: CurrencyItem = {
+  id: 'USD',
+  flag: '🇺🇸',
+  name: 'US Dollar',
+  symbol: '$',
+  fractionDigits: 2,
+};
+
+const makeSale = (
+  id: string,
+  satAmount: number,
+  overrides: Partial<TransactionData> = {},
+): TransactionData => ({
+  id,
+  timestamp: '2024-01-01T12:00:00Z',
+  transactionType: 'lightning',
+  paymentMethod: 'lightning',
+  amount: {
+    satAmount,
+    displayAmount: String(satAmount),
+    currency: usd,
+    isPrimaryAmountSats: true,
+  },
+  merchant: {username: 'testmerchant'},
+  invoice: {
+    paymentHash: `hash-${id}`,
+    paymentRequest: 'lnbc1...',
+    paymentSecret: 'secret',
+  },
+  status: 'completed',
+  ...overrides,
+});
+
+const makeRefund = (
+  id: string,
+  satAmount: number,
+  overrides: Partial<TransactionData> = {},
+): TransactionData =>
+  makeSale(id, satAmount, {
+    transactionType: 'refund',
+    invoice: {paymentHash: '', paymentRequest: '', paymentSecret: ''},
+    ...overrides,
+  });
+
+describe('getSalesContribution', () => {
+  it('returns the positive amount for a sale', () => {
+    expect(getSalesContribution(makeSale('s1', 1000))).toBe(1000);
+  });
+
+  it('returns a negative amount for a refund stored negative', () => {
+    expect(getSalesContribution(makeRefund('r1', -400))).toBe(-400);
+  });
+
+  it('returns a negative amount even for a refund stored positive (issue #64)', () => {
+    // A refund recorded with a positive amount must still deduct from sales
+    expect(getSalesContribution(makeRefund('r1', 400))).toBe(-400);
+  });
+
+  it('returns 0 for a standalone reward with no purchase amount', () => {
+    expect(
+      getSalesContribution(makeSale('s1', 0, {transactionType: 'standalone'})),
+    ).toBe(0);
+  });
+});
+
+describe('calculateSalesTotal', () => {
+  it('returns 0 for an empty transaction list', () => {
+    expect(calculateSalesTotal([])).toBe(0);
+  });
+
+  it('sums sale amounts when there are only sales', () => {
+    const transactions = [
+      makeSale('s1', 1000),
+      makeSale('s2', 2500),
+      makeSale('s3', 500, {transactionType: 'rewards-only'}),
+    ];
+
+    expect(calculateSalesTotal(transactions)).toBe(4000);
+  });
+
+  it('deducts a refund from the sales total (issue #64)', () => {
+    const transactions = [
+      makeSale('s1', 1000),
+      makeSale('s2', 2500),
+      makeRefund('r1', -1000),
+    ];
+
+    expect(calculateSalesTotal(transactions)).toBe(2500);
+  });
+
+  it('deducts a refund even when its amount was stored positive (issue #64)', () => {
+    const transactions = [makeSale('s1', 3000), makeRefund('r1', 1000)];
+
+    expect(calculateSalesTotal(transactions)).toBe(2000);
+  });
+
+  it('returns a negative total when there are only refunds', () => {
+    const transactions = [makeRefund('r1', -700), makeRefund('r2', -300)];
+
+    expect(calculateSalesTotal(transactions)).toBe(-1000);
+  });
+
+  it('fully cancels a sale refunded in full', () => {
+    const transactions = [makeSale('s1', 1500), makeRefund('r1', -1500)];
+
+    expect(calculateSalesTotal(transactions)).toBe(0);
+  });
+});
+
+describe('createRefundTransaction', () => {
+  const params = {
+    amount: {
+      satAmount: 800,
+      displayAmount: '8.00',
+      currency: usd,
+      isPrimaryAmountSats: true,
+    },
+    merchant: {username: 'testmerchant'},
+    refundOf: 'original-tx-1',
+  };
+
+  it('stores the amount as negative even when passed positive', () => {
+    const refund = createRefundTransaction(params);
+
+    expect(refund.amount.satAmount).toBe(-800);
+  });
+
+  it('keeps the amount negative when already passed negative', () => {
+    const refund = createRefundTransaction({
+      ...params,
+      amount: {...params.amount, satAmount: -800},
+    });
+
+    expect(refund.amount.satAmount).toBe(-800);
+  });
+
+  it('marks the transaction as a refund and links the original transaction', () => {
+    const refund = createRefundTransaction(params);
+
+    expect(refund.transactionType).toBe('refund');
+    expect(refund.refundOf).toBe('original-tx-1');
+    expect(refund.status).toBe('completed');
+  });
+
+  it('produces a transaction that passes validation', () => {
+    const refund = createRefundTransaction(params);
+
+    expect(validateTransactionData(refund)).toEqual({
+      isValid: true,
+      errors: [],
+    });
+  });
+
+  it('produces a transaction that deducts from the sales total', () => {
+    const sale = makeSale('s1', 1000);
+    const refund = createRefundTransaction(params);
+
+    expect(calculateSalesTotal([sale, refund])).toBe(200);
+  });
+});
+
+describe('validateTransactionData (refunds)', () => {
+  it('accepts a refund with a negative amount', () => {
+    const result = validateTransactionData(makeRefund('r1', -500));
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects a refund with a positive amount (would inflate sales, issue #64)', () => {
+    const result = validateTransactionData(makeRefund('r1', 500));
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      'Refund amount must be negative (a deduction from sales)',
+    );
+  });
+
+  it('rejects a refund with a zero amount', () => {
+    const result = validateTransactionData(makeRefund('r1', 0));
+
+    expect(result.isValid).toBe(false);
+  });
+
+  it('still rejects a negative amount on a non-refund sale', () => {
+    const result = validateTransactionData(makeSale('s1', -100));
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      'Amount must be greater than 0 for non-standalone transactions',
+    );
+  });
+
+  it('still accepts a valid positive sale', () => {
+    const result = validateTransactionData(makeSale('s1', 100));
+
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/src/hooks/usePrint.tsx
+++ b/src/hooks/usePrint.tsx
@@ -111,9 +111,13 @@ const usePrint = () => {
   };
 
   const printReceipt = (receiptData: ReceiptData) => {
+    const headline =
+      receiptData.transactionType === 'refund'
+        ? 'Refund completed'
+        : 'Sale completed';
     PrinterModule.setAlignment(1);
     PrinterModule.setTextBold(true);
-    PrinterModule.printText('Sale completed\n');
+    PrinterModule.printText(`${headline}\n`);
     PrinterModule.printText(
       `${receiptData.currency.symbol} ${receiptData.displayAmount}\n`,
     );
@@ -139,11 +143,15 @@ const usePrint = () => {
   };
 
   const printReceiptHTML = async (receiptData: ReceiptData) => {
+    const headline =
+      receiptData.transactionType === 'refund'
+        ? 'Refund completed'
+        : 'Sale completed';
     await RNPrint.print({
       html: `
           <div style="display: flex;flex-direction: column;">
             <div style="display: flex;flex-direction: column;align-items: center;">
-              <p style="padding: 0; margin: 0; margin-bottom: 10px; font-size: 13; font-weight: 600">Sale completed</p>
+              <p style="padding: 0; margin: 0; margin-bottom: 10px; font-size: 13; font-weight: 600">${headline}</p>
               <p style="padding: 0; margin: 0; font-size: 10">${
                 receiptData.currency.symbol
               } ${receiptData.displayAmount}</p>

--- a/src/screens/TransactionHistory.tsx
+++ b/src/screens/TransactionHistory.tsx
@@ -20,6 +20,9 @@ import Refresh from '../assets/icons/refresh.svg';
 // store
 import {clearTransactionHistory} from '../store/slices/transactionHistorySlice';
 
+// utils
+import {calculateSalesTotal} from '../utils/transactionHelpers';
+
 const {width: screenWidth} = Dimensions.get('window');
 
 // Responsive scaling functions
@@ -103,19 +106,26 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
     const standaloneCount = transactions.filter(
       t => t.transactionType === 'standalone',
     ).length;
+    const refundCount = transactions.filter(
+      t => t.transactionType === 'refund',
+    ).length;
     const withRewardsCount = transactions.filter(t => t.reward).length;
     const totalRewardsGiven = transactions.reduce(
       (sum, transaction) => sum + (transaction.reward?.rewardAmount || 0),
       0,
     );
+    // Net sales: sale amounts add, refund amounts deduct (issue #64)
+    const totalSales = calculateSalesTotal(transactions);
 
     return {
       total: transactions.length,
       lightning: lightningCount,
       external: externalCount,
       standalone: standaloneCount,
+      refunds: refundCount,
       withRewards: withRewardsCount,
       totalRewards: totalRewardsGiven,
+      totalSales,
     };
   }, [transactions]);
 
@@ -128,6 +138,8 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
         return {icon: '💳', label: 'External Payment', color: '#FF9500'};
       case 'standalone':
         return {icon: '🏷️', label: 'Reward Only', color: '#6C757D'};
+      case 'refund':
+        return {icon: '↩️', label: 'Refund', color: '#B31B1B'};
       default:
         return {icon: '📄', label: 'Transaction', color: '#6C757D'};
     }
@@ -268,6 +280,12 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
           <HeaderTitle>Transaction History</HeaderTitle>
           <HeaderSubtitle>
             {statistics.total} transactions
+            {statistics.total > 0 && (
+              <>
+                {' • '}
+                {statistics.totalSales} points in sales
+              </>
+            )}
             {statistics.totalRewards > 0 && (
               <>
                 {' • '}

--- a/src/screens/TransactionHistory.tsx
+++ b/src/screens/TransactionHistory.tsx
@@ -24,7 +24,10 @@ import {
 } from '../store/slices/transactionHistorySlice';
 
 // utils
-import {formatTransactionAmount} from '../utils/transactionHelpers';
+import {
+  formatTransactionAmount,
+  getReceiptAmounts,
+} from '../utils/transactionHelpers';
 
 const {width: screenWidth} = Dimensions.get('window');
 
@@ -57,11 +60,14 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
   };
 
   const onReprintTransaction = (transaction: TransactionData) => {
+    // Refund amounts print signed — same sign rules as the history rows,
+    // so a reprinted refund receipt can never read like a sale receipt.
+    const {satAmount, displayAmount} = getReceiptAmounts(transaction);
     const receiptData: ReceiptData = {
       id: transaction.id,
       timestamp: transaction.timestamp,
-      satAmount: transaction.amount.satAmount,
-      displayAmount: transaction.amount.displayAmount,
+      satAmount,
+      displayAmount,
       currency: transaction.amount.currency,
       isPrimaryAmountSats: transaction.amount.isPrimaryAmountSats,
       username: transaction.merchant.username,

--- a/src/screens/TransactionHistory.tsx
+++ b/src/screens/TransactionHistory.tsx
@@ -18,10 +18,13 @@ import Check from '../assets/icons/check.svg';
 import Refresh from '../assets/icons/refresh.svg';
 
 // store
-import {clearTransactionHistory} from '../store/slices/transactionHistorySlice';
+import {
+  clearTransactionHistory,
+  selectTransactionStatistics,
+} from '../store/slices/transactionHistorySlice';
 
 // utils
-import {calculateSalesTotal} from '../utils/transactionHelpers';
+import {formatTransactionAmount} from '../utils/transactionHelpers';
 
 const {width: screenWidth} = Dimensions.get('window');
 
@@ -37,7 +40,8 @@ type FilterType =
   | 'with-rewards'
   | 'lightning'
   | 'external'
-  | 'standalone';
+  | 'standalone'
+  | 'refund';
 
 const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
   const navigations = useNavigation<NavigationProp>();
@@ -77,7 +81,11 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
   const filteredTransactions = React.useMemo(() => {
     switch (activeFilter) {
       case 'with-rewards':
-        return transactions.filter(transaction => transaction.reward);
+        // Matches selectTransactionsWithRewards / the statistics count
+        return transactions.filter(
+          transaction =>
+            transaction.reward && transaction.reward.rewardAmount > 0,
+        );
       case 'lightning':
         return transactions.filter(
           transaction => transaction.transactionType === 'lightning',
@@ -90,44 +98,31 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
         return transactions.filter(
           transaction => transaction.transactionType === 'standalone',
         );
+      case 'refund':
+        return transactions.filter(
+          transaction => transaction.transactionType === 'refund',
+        );
       default:
         return transactions;
     }
   }, [transactions, activeFilter]);
 
-  // Enhanced statistics calculation
-  const statistics = React.useMemo(() => {
-    const lightningCount = transactions.filter(
-      t => t.transactionType === 'lightning',
-    ).length;
-    const externalCount = transactions.filter(
-      t => t.transactionType === 'rewards-only',
-    ).length;
-    const standaloneCount = transactions.filter(
-      t => t.transactionType === 'standalone',
-    ).length;
-    const refundCount = transactions.filter(
-      t => t.transactionType === 'refund',
-    ).length;
-    const withRewardsCount = transactions.filter(t => t.reward).length;
-    const totalRewardsGiven = transactions.reduce(
-      (sum, transaction) => sum + (transaction.reward?.rewardAmount || 0),
-      0,
-    );
-    // Net sales: sale amounts add, refund amounts deduct (issue #64)
-    const totalSales = calculateSalesTotal(transactions);
-
-    return {
-      total: transactions.length,
-      lightning: lightningCount,
-      external: externalCount,
-      standalone: standaloneCount,
-      refunds: refundCount,
-      withRewards: withRewardsCount,
-      totalRewards: totalRewardsGiven,
-      totalSales,
-    };
-  }, [transactions]);
+  // Statistics come from the single shared selector
+  // (selectTransactionStatistics) — only the field names are mapped here.
+  const stats = useAppSelector(selectTransactionStatistics);
+  const statistics = React.useMemo(
+    () => ({
+      total: stats.totalTransactions,
+      lightning: stats.lightningCount,
+      external: stats.externalCount,
+      standalone: stats.standaloneCount,
+      refunds: stats.refundCount,
+      withRewards: stats.withRewardsCount,
+      totalRewards: stats.totalRewardsDistributed,
+      totalSales: stats.totalSales,
+    }),
+    [stats],
+  );
 
   // Get transaction type badge info
   const getTransactionTypeBadge = (transaction: TransactionData) => {
@@ -169,11 +164,7 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
         {/* Compact header with amount and status/badges in one row */}
         <CompactHeader>
           <AmountAndMerchant>
-            <PrimaryAmount>
-              {item.amount.isPrimaryAmountSats
-                ? `${item.amount.satAmount} points`
-                : `${item.amount.currency.symbol} ${item.amount.displayAmount}`}
-            </PrimaryAmount>
+            <PrimaryAmount>{formatTransactionAmount(item)}</PrimaryAmount>
             <MerchantText>to {item.merchant.username}</MerchantText>
           </AmountAndMerchant>
 
@@ -263,6 +254,8 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
           ? 'No external payment transactions found'
           : activeFilter === 'standalone'
           ? 'No standalone reward transactions found'
+          : activeFilter === 'refund'
+          ? 'No refund transactions found'
           : 'No transactions found'}
       </EmptyText>
       <EmptySubtext>
@@ -343,6 +336,16 @@ const TransactionHistory: React.FC<Props> = ({navigation: _navigation}) => {
                   onPress={() => setActiveFilter('standalone')}>
                   <FilterButtonText active={activeFilter === 'standalone'}>
                     🏷️ Rewards ({statistics.standalone})
+                  </FilterButtonText>
+                </FilterButton>
+              )}
+
+              {statistics.refunds > 0 && (
+                <FilterButton
+                  active={activeFilter === 'refund'}
+                  onPress={() => setActiveFilter('refund')}>
+                  <FilterButtonText active={activeFilter === 'refund'}>
+                    ↩️ Refunds ({statistics.refunds})
                   </FilterButtonText>
                 </FilterButton>
               )}

--- a/src/store/slices/transactionHistorySlice.ts
+++ b/src/store/slices/transactionHistorySlice.ts
@@ -1,6 +1,9 @@
 import {createSlice, PayloadAction, createSelector} from '@reduxjs/toolkit';
 
-import {calculateSalesTotal} from '../../utils/transactionHelpers';
+import {
+  calculateSalesTotal,
+  validateTransactionData,
+} from '../../utils/transactionHelpers';
 
 const initialState: TransactionHistoryState = {
   transactions: [],
@@ -13,7 +16,31 @@ export const transactionHistorySlice = createSlice({
   initialState,
   reducers: {
     addTransaction: (state, action: PayloadAction<TransactionData>) => {
-      const newTransaction = action.payload;
+      let newTransaction = action.payload;
+
+      // Refunds must deduct from sales: normalize the sign at the store
+      // boundary so a positive-stored refund can never inflate the sales
+      // total (issue #64).
+      if (newTransaction.transactionType === 'refund') {
+        newTransaction = {
+          ...newTransaction,
+          amount: {
+            ...newTransaction.amount,
+            satAmount: -Math.abs(newTransaction.amount.satAmount),
+          },
+        };
+      }
+
+      // Reject payloads that fail validation (e.g. zero-amount refunds,
+      // missing merchant) instead of silently recording bad data.
+      const validation = validateTransactionData(newTransaction);
+      if (!validation.isValid) {
+        console.warn(
+          '[transactionHistory] Dropped invalid transaction:',
+          validation.errors.join('; '),
+        );
+        return;
+      }
 
       // Add to beginning of array (most recent first)
       state.transactions.unshift(newTransaction);

--- a/src/store/slices/transactionHistorySlice.ts
+++ b/src/store/slices/transactionHistorySlice.ts
@@ -1,5 +1,7 @@
 import {createSlice, PayloadAction, createSelector} from '@reduxjs/toolkit';
 
+import {calculateSalesTotal} from '../../utils/transactionHelpers';
+
 const initialState: TransactionHistoryState = {
   transactions: [],
   lastTransaction: undefined,
@@ -125,6 +127,9 @@ export const selectTransactionStatistics = createSelector(
     const standaloneCount = transactions.filter(
       (t: TransactionData) => t.transactionType === 'standalone',
     ).length;
+    const refundCount = transactions.filter(
+      (t: TransactionData) => t.transactionType === 'refund',
+    ).length;
     const withRewardsCount = transactions.filter(
       (t: TransactionData) => t.reward && t.reward.rewardAmount > 0,
     ).length;
@@ -132,18 +137,23 @@ export const selectTransactionStatistics = createSelector(
       (sum: number, t: TransactionData) => sum + (t.reward?.rewardAmount || 0),
       0,
     );
+    // Net sales: sale amounts add, refund amounts deduct (issue #64)
+    const totalSales = calculateSalesTotal(transactions);
 
     return {
       totalTransactions,
       lightningCount,
       externalCount,
       standaloneCount,
+      refundCount,
       withRewardsCount,
       totalRewardsDistributed,
+      totalSales,
       transactionTypes: {
         lightning: lightningCount,
         external: externalCount,
         standalone: standaloneCount,
+        refund: refundCount,
       },
     };
   },

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -1,5 +1,5 @@
 // Transaction type enumeration for different payment flows
-type TransactionType = 'lightning' | 'rewards-only' | 'standalone';
+type TransactionType = 'lightning' | 'rewards-only' | 'standalone' | 'refund';
 
 // Payment method types for tracking how the payment was made
 type PaymentMethod =
@@ -32,6 +32,7 @@ interface TransactionData {
   };
   memo?: string;
   status: 'pending' | 'completed' | 'failed';
+  refundOf?: string; // id of the original transaction this refund reverses
   reward?: {
     rewardAmount: number; // Reward sats earned
     rewardRate: number; // Percentage rate used (e.g., 0.02 for 2%)

--- a/src/utils/transactionHelpers.ts
+++ b/src/utils/transactionHelpers.ts
@@ -141,6 +141,87 @@ export const createStandaloneTransaction = (params: {
 };
 
 /**
+ * Create a refund transaction data object
+ *
+ * Refunds are stored with a NEGATIVE satAmount so that any summation over
+ * transaction amounts deducts them from the sales total by construction
+ * (issue #64: refunds were added to the sales total instead of deducted).
+ *
+ * @param params - Refund parameters (satAmount may be passed positive or
+ *   negative; it is normalized to negative)
+ * @returns Complete TransactionData object for the refund
+ */
+export const createRefundTransaction = (params: {
+  amount: {
+    satAmount: number;
+    displayAmount: string;
+    currency: CurrencyItem;
+    isPrimaryAmountSats: boolean;
+  };
+  merchant: {
+    username: string;
+  };
+  refundOf?: string;
+  memo?: string;
+}): TransactionData => {
+  return {
+    id: `refund_${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    transactionType: 'refund',
+    paymentMethod: 'lightning',
+    amount: {
+      ...params.amount,
+      satAmount: -Math.abs(params.amount.satAmount),
+    },
+    merchant: params.merchant,
+    invoice: {
+      paymentHash: '', // Refunds are outgoing payments, no invoice of our own
+      paymentRequest: '',
+      paymentSecret: '',
+    },
+    memo: params.memo || 'Refund',
+    status: 'completed',
+    refundOf: params.refundOf,
+  };
+};
+
+/**
+ * Signed sat amount a transaction contributes to the sales total.
+ *
+ * Sales add their amount; refunds always SUBTRACT theirs — even if a refund
+ * was stored with a positive satAmount (defensive against issue #64, where
+ * refund amounts were added to the sales total instead of deducted).
+ *
+ * @param transaction - Transaction to evaluate
+ * @returns Signed contribution in sats
+ */
+export const getSalesContribution = (transaction: TransactionData): number => {
+  const satAmount = transaction.amount?.satAmount || 0;
+
+  if (transaction.transactionType === 'refund') {
+    return -Math.abs(satAmount);
+  }
+
+  return satAmount;
+};
+
+/**
+ * Net sales total for a list of transactions, in sats.
+ * Sales add; refunds deduct.
+ *
+ * @param transactions - Transactions to total
+ * @returns Net sales total in sats
+ */
+export const calculateSalesTotal = (
+  transactions: TransactionData[],
+): number => {
+  return transactions.reduce(
+    (sum, transaction) => sum + getSalesContribution(transaction),
+    0,
+  );
+};
+
+/**
  * Create reward data from calculation result
  * @param calculation - Result from calculateReward function
  * @param isStandalone - Whether this is a standalone reward
@@ -170,7 +251,15 @@ export const validateTransactionData = (
 ) => {
   const errors: string[] = [];
 
-  if (
+  if (transactionData.transactionType === 'refund') {
+    // Refunds must be stored negative so they deduct from the sales total
+    if (
+      !transactionData.amount?.satAmount ||
+      transactionData.amount.satAmount >= 0
+    ) {
+      errors.push('Refund amount must be negative (a deduction from sales)');
+    }
+  } else if (
     !transactionData.amount?.satAmount ||
     transactionData.amount.satAmount < 0
   ) {

--- a/src/utils/transactionHelpers.ts
+++ b/src/utils/transactionHelpers.ts
@@ -222,6 +222,35 @@ export const calculateSalesTotal = (
 };
 
 /**
+ * User-facing primary amount string for a transaction row.
+ *
+ * Sales render as stored ('1000 points' / '$ 10.00'). Refunds always render
+ * signed — '-800 points' / '-$ 8.00' — even if the refund was stored with a
+ * positive amount (issue #64), so a refund is never visually mistakable for
+ * a sale.
+ *
+ * @param transaction - Transaction to format
+ * @returns Primary amount display string
+ */
+export const formatTransactionAmount = (
+  transaction: TransactionData,
+): string => {
+  const {satAmount, displayAmount, currency, isPrimaryAmountSats} =
+    transaction.amount;
+
+  if (transaction.transactionType === 'refund') {
+    if (isPrimaryAmountSats) {
+      return `${-Math.abs(satAmount)} points`;
+    }
+    return `-${currency.symbol} ${displayAmount.replace(/^-/, '')}`;
+  }
+
+  return isPrimaryAmountSats
+    ? `${satAmount} points`
+    : `${currency.symbol} ${displayAmount}`;
+};
+
+/**
  * Create reward data from calculation result
  * @param calculation - Result from calculateReward function
  * @param isStandalone - Whether this is a standalone reward
@@ -263,7 +292,17 @@ export const validateTransactionData = (
     !transactionData.amount?.satAmount ||
     transactionData.amount.satAmount < 0
   ) {
-    if (transactionData.transactionType !== 'standalone') {
+    // Zero-amount rewards-only transactions are how standalone NFC-card taps
+    // are recorded by the Rewards screen — the reward is the substance there.
+    const isZeroAmountReward =
+      transactionData.transactionType === 'rewards-only' &&
+      transactionData.amount?.satAmount === 0 &&
+      (transactionData.reward?.rewardAmount ?? 0) > 0;
+
+    if (
+      transactionData.transactionType !== 'standalone' &&
+      !isZeroAmountReward
+    ) {
       errors.push(
         'Amount must be greater than 0 for non-standalone transactions',
       );

--- a/src/utils/transactionHelpers.ts
+++ b/src/utils/transactionHelpers.ts
@@ -222,12 +222,42 @@ export const calculateSalesTotal = (
 };
 
 /**
+ * Receipt-facing amounts for a transaction. Refunds always come out
+ * negative — both the sat amount and the fiat display string — even if the
+ * refund was stored with a positive amount (issue #64), so a reprinted
+ * refund receipt is never mistakable for a sale receipt. Sales pass
+ * through as stored.
+ *
+ * Shared by the history rows (formatTransactionAmount) and the receipt
+ * builder (TransactionHistory reprint → usePrint), so the two surfaces
+ * can never disagree on refund signs.
+ *
+ * @param transaction - Transaction to derive receipt amounts from
+ * @returns Signed satAmount and displayAmount for ReceiptData
+ */
+export const getReceiptAmounts = (
+  transaction: TransactionData,
+): {satAmount: number; displayAmount: string} => {
+  const {satAmount, displayAmount} = transaction.amount;
+
+  if (transaction.transactionType === 'refund') {
+    return {
+      satAmount: -Math.abs(satAmount),
+      displayAmount: `-${displayAmount.replace(/^-/, '')}`,
+    };
+  }
+
+  return {satAmount, displayAmount};
+};
+
+/**
  * User-facing primary amount string for a transaction row.
  *
  * Sales render as stored ('1000 points' / '$ 10.00'). Refunds always render
  * signed — '-800 points' / '-$ 8.00' — even if the refund was stored with a
  * positive amount (issue #64), so a refund is never visually mistakable for
- * a sale.
+ * a sale. Sign rules come from getReceiptAmounts so rows and receipts
+ * always agree.
  *
  * @param transaction - Transaction to format
  * @returns Primary amount display string
@@ -235,19 +265,19 @@ export const calculateSalesTotal = (
 export const formatTransactionAmount = (
   transaction: TransactionData,
 ): string => {
-  const {satAmount, displayAmount, currency, isPrimaryAmountSats} =
-    transaction.amount;
+  const {currency, isPrimaryAmountSats} = transaction.amount;
+  const {satAmount, displayAmount} = getReceiptAmounts(transaction);
+
+  if (isPrimaryAmountSats) {
+    return `${satAmount} points`;
+  }
 
   if (transaction.transactionType === 'refund') {
-    if (isPrimaryAmountSats) {
-      return `${-Math.abs(satAmount)} points`;
-    }
+    // Fiat-primary refunds carry the sign ahead of the symbol: '-$ 8.00'
     return `-${currency.symbol} ${displayAmount.replace(/^-/, '')}`;
   }
 
-  return isPrimaryAmountSats
-    ? `${satAmount} points`
-    : `${currency.symbol} ${displayAmount}`;
+  return `${currency.symbol} ${displayAmount}`;
 };
 
 /**


### PR DESCRIPTION
## Root cause

The transaction model had no representation of refunds at all: `TransactionType` only covered `lightning | rewards-only | standalone`, every stored `satAmount` was positive (and `validateTransactionData` *rejected* negative amounts), and every summation over transaction amounts treated each entry as a positive sale. Any refund recorded in the history therefore **added** its amount to the sales total instead of deducting it — the earlier refund attempt (#56, closed) flagged the original sale as refunded rather than storing a signed deduction, which is exactly the shape that produces this bug.

## Scope — groundwork; issue #64 stays open

**Merging this PR must not mark issue #64 as done.** No production flow records a refund transaction yet — the refund-recording UX is #46 — so the reporter's scenario cannot produce a corrected total until that lands. This PR makes the accounting, validation, storage, and display refund-correct so #46 lands on sound totals instead of reintroducing the inflation bug.

Part of #46. Refs #64 (leave open until a recording flow ships).

> [!NOTE]
> No commit in this branch carries a GitHub closing keyword (the original `Fixes` line was reworded to a plain `Refs` reference), so merging — by merge commit, squash, or rebase — will not auto-close issue #64. It should be closed manually only once #46 ships a refund-recording flow.

## Fix

- **`src/types/transaction.d.ts`** — add `'refund'` to `TransactionType`, plus optional `refundOf` linking a refund to the original transaction.
- **`src/utils/transactionHelpers.ts`** —
  - `getSalesContribution` / `calculateSalesTotal`: sales add their amount, refunds **always subtract** theirs — even if a refund was stored with a positive sign.
  - `createRefundTransaction`: normalizes refund amounts to **negative** so any naive summation deducts them by construction.
  - `validateTransactionData`: refunds must be negative; the zero-amount `rewards-only` shape the Rewards screen records for NFC card taps is now explicitly valid (it previously failed the amount rule, which mattered once validation became enforced — see below).
  - `getReceiptAmounts` (new): the single source of refund sign rules — refunds always come out negative (sats and fiat display string), even if stored positive; sales pass through as stored.
  - `formatTransactionAmount` (new): refunds always render signed — `-800 points` / `-$ 8.00` — even if stored positive, so a refund row is never visually mistakable for a sale. Derives its signs from `getReceiptAmounts`.
- **`src/store/slices/transactionHistorySlice.ts`** —
  - `selectTransactionStatistics` reports `totalSales` (net of refunds) and `refundCount` via the shared helper.
  - `addTransaction` now **enforces** `validateTransactionData`: invalid payloads are dropped and logged instead of silently recorded, and refund sign is normalized at the store boundary — a positive-stored refund can never inflate totals.
- **`src/screens/TransactionHistory.tsx`** —
  - Header shows the net sales total computed by the shared selector; the screen's duplicated inline statistics memo is **gone** — it consumes `selectTransactionStatistics` and only maps field names (the two copies had already drifted on the with-rewards count).
  - Refunds get their own type badge, a **Refunds filter chip** (with `'refund'` in `FilterType`, a filter case, and empty-state text), and signed fiat rendering via `formatTransactionAmount`.
  - The With Rewards chip and filter both use the selector's `rewardAmount > 0` semantics.
  - **Reprint** builds `ReceiptData` from `getReceiptAmounts`, so a reprinted refund receipt prints signed fiat (`-8.00`) and signed sats — never indistinguishable from a sale receipt.

## Tests

- **`__tests__/utils/transactionHelpers.test.ts`**: sales/refund totals incl. positive-stored refunds, `createRefundTransaction` sign normalization + validation round-trip, validation sign rules, zero-amount rewards-only acceptance (with reward) and rejection (without), `formatTransactionAmount` signed rendering incl. no-double-sign, `getReceiptAmounts` sign rules (sale passthrough, negative- and positive-stored refunds, no double sign).
- **`__tests__/store/transactionHistorySlice.test.ts`**: `totalSales` scenarios; reducer validation gate (invalid payload dropped + logged, zero-amount refund dropped), refund sign normalized at the boundary, NFC-tap zero-amount rewards-only shape still recorded (regression guard for the gate).
- **`__tests__/screens/TransactionHistory.test.tsx`**: header deducts refunds (600, not 1400), fiat-primary refund renders `-$ 4.00` (sale stays `$ 10.00`), Refunds chip filters to refund rows only, zero-amount reward excluded from the With Rewards chip, reprint hands the printer signed refund amounts (incl. legacy positive-stored rows) and stored amounts for sales.

`yarn test --runInBand`: 19 suites, 188 tests passing. `yarn lint` and `yarn typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAxSGEsL2LsMx1uCjAzHH
