### PR TITLE
fix(deps): bump resolutions — shell-quote 1.9.0, postcss 8.5.23, nanoid 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "picomatch": "2.3.2",
     "styled-components/postcss": "8.5.23",
     "shell-quote": "1.9.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "ws": "7.5.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,8 +98,9 @@
     "lodash": "4.18.1",
     "node-forge": "1.4.0",
     "picomatch": "2.3.2",
-    "styled-components/postcss": "8.5.10",
-    "shell-quote": "1.8.4",
+    "styled-components/postcss": "8.5.23",
+    "shell-quote": "1.9.0",
+    "nanoid": "3.3.17",
     "ws": "7.5.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6463,10 +6463,10 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.3.17, nanoid@^3.3.11, nanoid@^3.3.16:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
+nanoid@3.3.18, nanoid@^3.3.11, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6463,10 +6463,10 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@3.3.17, nanoid@^3.3.11, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6899,12 +6899,12 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@8.5.10:
-  version "8.5.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.4.31, postcss@8.5.23:
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -7747,10 +7747,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.8.4, shell-quote@^1.6.1, shell-quote@^1.7.3:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+shell-quote@1.9.0, shell-quote@^1.6.1, shell-quote@^1.7.3:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Security-hygiene bump of the yarn `resolutions` block, following the 2026-08-12 Dependabot triage of this repo (41 alerts reviewed → 0 judged device-reachable). These pins clear 6 alerts (including 5 high). Notably, the existing `shell-quote` pin (`1.8.4`) was itself the vulnerable version flagged by alert #124 — the pin intended as a fix was pinning the vulnerability in place.

## Changes

| Resolution | Before (resolved) | After (resolved) | Alerts |
|---|---|---|---|
| `shell-quote` | 1.8.4 | **1.9.0** | #124 |
| `styled-components/postcss` | 8.5.10 | **8.5.23** | #128, #129, #138 |
| `nanoid` (new pin) | 3.3.11 (via `^3.3.11`) | **3.3.18** | #136, #137 |

Existing pins (`lodash`, `node-forge`, `picomatch`, `ws`) are untouched. The `yarn.lock` diff is scoped to exactly these three packages.

The postcss vulnerabilities were judged unreachable on-device in the triage; that pin is belt-and-braces. This PR updates pinned versions only — it does not change or re-do the triage's reachability analysis, and no Dependabot alerts have been dismissed.

## Verification

- `yarn install` regenerated `yarn.lock`; verified resolved versions: all `shell-quote` ranges → 1.9.0, `postcss` (under styled-components) → 8.5.23, all `nanoid` ranges → 3.3.18
- `yarn jest`: 20/20 suites, 193/193 tests passing
- `npx tsc --noEmit`: clean
- `npx prettier --check package.json`: clean
- No source changes (package.json + yarn.lock only), so no eslint surface

## Caveat — device build before next release

This is a React Native app; no headless runtime smoke is possible. These resolutions touch styled-components' css pipeline (postcss) and react-navigation's key generation (nanoid), so a device build should be run before the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAxSGEsL2LsMx1uCjAzHH

